### PR TITLE
Add hover labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 format:
 	black . -l 79
+debug-client:
+	cd client; npm start
+debug-server:
+	FLASK_APP=main.py FLASK_DEBUG=1 flask run
 deploy: openfisca_data openfisca_uk test
 	rm -rf server/static
 	cd client; npm run build

--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,7 @@
 runtime: python37
 instance_class: B4_1G
-basic_scaling:
-  max_instances: 1
-  idle_timeout: 15m
+manual_scaling:
+  instances: 1
 handlers:
 - url: /.*
   script: auto

--- a/client/src/js/pages/population-results.jsx
+++ b/client/src/js/pages/population-results.jsx
@@ -50,7 +50,7 @@ class PopulationResults extends React.Component {
 							</div> :
 							this.state.error ?
 								<div className="d-flex justify-content-center align-items-center" style={{minHeight: 400}}>
-									<LoadingResultsPane noSpin message="An error occurred"/>
+									<LoadingResultsPane noSpin message="Something went wrong (try navigating back and returning to this page)"/>
 								</div> :
 								<PopulationResultsPane results={this.state.results} />
 					}

--- a/client/src/js/pages/situation-results.jsx
+++ b/client/src/js/pages/situation-results.jsx
@@ -74,7 +74,7 @@ class SituationResults extends React.Component {
 							</div> :
 							this.state.error ?
 								<div className="d-flex justify-content-center align-items-center" style={{minHeight: 400}}>
-									<LoadingResultsPane noSpin message="An error occurred"/>
+									<LoadingResultsPane noSpin message="Something went wrong (try navigating back and returning to this page)"/>
 								</div> :
 								<SituationResultsPane results={this.state.results} />
 					}

--- a/client/src/js/pages/situation-results.jsx
+++ b/client/src/js/pages/situation-results.jsx
@@ -44,7 +44,7 @@ class SituationResults extends React.Component {
 				submission[variableName] = variable.value;
 			}
 		}*/
-		let url = new URL("http://uk.policyengine.org/api/situation-reform");
+		let url = new URL("https://uk.policyengine.org/api/situation-reform");
 		url.search = new URLSearchParams(submission).toString();
 		this.setState({ waiting: true }, () => {
 			fetch(url)

--- a/server/situations/charts.py
+++ b/server/situations/charts.py
@@ -23,6 +23,7 @@ def budget_chart(baseline, reformed):
         df,
         x="Employment income",
         y=["Baseline", "Reform"],
+        labels={"variable": "Policy", "value": "Net income"},
         color_discrete_map={"Baseline": GRAY, "Reform": BLUE},
     )
     return json.loads(
@@ -57,6 +58,7 @@ def mtr_chart(baseline, reformed):
         df,
         x="Employment income",
         y=["Baseline", "Reform"],
+        labels={"variable": "Policy", "value": "Effective MTR"},
         color_discrete_map={"Baseline": GRAY, "Reform": BLUE},
     )
     return json.loads(
@@ -176,10 +178,16 @@ def budget_waterfall_chart(baseline, reformed):
         ]
     )
     fig = px.bar(
-        df,
-        x="variable",
-        y="value",
-        color="type",
+        df.rename(
+            columns={
+                "type": "Type",
+                "value": "Amount",
+                "variable": "Component",
+            }
+        ),
+        x="Component",
+        y="Amount",
+        color="Type",
         animation_frame="Policy",
         color_discrete_map={
             "Gain": BLUE,


### PR DESCRIPTION
This ensures all the charts have informative labels, and not any exposed Plotly defaults. I used the format below, e.g.

Policy=Baseline
Employment income=£x
Effective MTR=x%

Fixes #10 