### PR TITLE
Fix timeout bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ ADD . /app
 
 # Run a WSGI server to serve the application. gunicorn must be declared as
 # a dependency in requirements.txt.
-CMD gunicorn -b :$PORT main:app
+CMD gunicorn -b :$PORT main:app --timeout 240


### PR DESCRIPTION
The `gunicorn` setup by default terminates instances which do not finish endpoints in 30 seconds or less. This raises it to 4 minutes.