### PR TITLE
Reinstate openfisca-uk dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/PolicyEngine/openfisca-uk
 git+https://github.com/ubicenter/ubicenter.py
 git+https://github.com/PSLmodels/synthimpute
 plotly


### PR DESCRIPTION
The deploy action failed - but after it deployed, so the site is failing to boot.