### PR TITLE
Fix bug which neutralised thresholds

### DIFF
--- a/policy_engine_uk/app.py
+++ b/policy_engine_uk/app.py
@@ -28,7 +28,7 @@ from policy_engine_uk.situations.charts import (
 )
 from openfisca_uk_data import FRS_WAS_Imputation
 
-VERSION = "0.0.13"
+VERSION = "0.1.2"
 USE_CACHE = True
 logging.getLogger("werkzeug").disabled = True
 

--- a/policy_engine_uk/simulation/parameters.yaml
+++ b/policy_engine_uk/simulation/parameters.yaml
@@ -24,15 +24,12 @@ add_rate:
   parameter: tax.income_tax.rates.uk[2].rate
 basic_threshold:
   name: Basic threshold
-  multiplier: 1.e-2
   parameter: tax.income_tax.rates.uk[0].threshold
 higher_threshold:
   name: Higher threshold
-  multiplier: 1.e-2
   parameter: tax.income_tax.rates.uk[1].threshold
 add_threshold:
   name: Additional threshold
-  multiplier: 1.e-2
   parameter: tax.income_tax.rates.uk[2].threshold
 personal_allowance:
   name: PA

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name="PolicyEngine-UK",
-    version="0.1.1",
+    version="0.1.2",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/ubicenter/policyengine-uk",


### PR DESCRIPTION
Creating a massive surplus (thresholds were divided by 100 by mistake, causing everyone to shift to the additional rate).

@MaxGhenis  FYI