### PR TITLE
Bump version

### DIFF
--- a/policy_engine_uk/app.py
+++ b/policy_engine_uk/app.py
@@ -28,7 +28,7 @@ from policy_engine_uk.situations.charts import (
 )
 from openfisca_uk_data import FRS_WAS_Imputation
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 USE_CACHE = True
 logging.getLogger("werkzeug").disabled = True
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name="PolicyEngine-UK",
-    version="0.1.2",
+    version="0.1.3",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/ubicenter/policyengine-uk",


### PR DESCRIPTION
The LVT issue was fixed, but the cached results still exist for 1% and 2%.