### PR TITLE
Add to FAQ, fix chart label, add UC reduction rate and CB amounts

### DIFF
--- a/client/public/faq.md
+++ b/client/public/faq.md
@@ -15,8 +15,13 @@ See our [demo video](https://youtu.be/P7ELqxEHRhE) for a tour of the interface.
 
 ### Who created PolicyEngine?
 
-Nikhil Woodruff and Max Ghenis built the PolicyEngine product while working at the UBI Center, a research organisation that studies universal basic income policies.
-They then created PolicyEngine as an independent nonprofit (fiscally sponsored by the [PSL Foundation](https://opencollective.com/psl)) to serve the broader policy community and ultimately the public, striving to make everyone a policymaker.
+**Max Ghenis** is the co-founder and CEO of PolicyEngine.
+He is also the founder and president of the UBI Center, a think tank researching universal basic income policies, and was previously a data scientist at Google.
+Max has a master's degree in Data, Economics, and Development Policy from MIT and a bachelor's degree in operations research from UC Berkeley.
+
+**Nikhil Woodruff** is the co-founder and CTO of PolicyEngine.
+He is also a tech lead at the UBI Center, a think tank researching universal basic income policies, and was previously a data scientist at Caspian, where he worked in improving anti-money laundering investigations.
+He is currently on leave from Durham University's Computer Science program.
 
 
 ### When will PolicyEngine be available in my country?

--- a/client/public/faq.md
+++ b/client/public/faq.md
@@ -21,7 +21,7 @@ Max has a master's degree in Data, Economics, and Development Policy from MIT an
 
 **Nikhil Woodruff** is the co-founder and CTO of PolicyEngine.
 He is also a tech lead at the UBI Center, a think tank researching universal basic income policies, and was previously a data scientist at Caspian, where he worked in improving anti-money laundering investigations.
-He is currently on leave from Durham University's Computer Science program.
+Nikhil is currently on leave from Durham University's Computer Science program.
 
 
 ### When will PolicyEngine be available in my country?

--- a/client/src/js/pages/policy/controls.jsx
+++ b/client/src/js/pages/policy/controls.jsx
@@ -233,6 +233,7 @@ function PolicyControls(props) {
 			"UC_single_old",
 			"UC_couple_young",
 			"UC_couple_old",
+			"UC_reduction_rate",
 		]
 	};
 	const names = controlSet[props.selected];

--- a/client/src/js/pages/policy/controls.jsx
+++ b/client/src/js/pages/policy/controls.jsx
@@ -223,6 +223,8 @@ function PolicyControls(props) {
 		],
 		child_benefit: [
 			"abolish_CB",
+			"CB_eldest",
+			"CB_additional",
 		],
 		state_pension: [
 			"abolish_SP",

--- a/client/src/js/pages/policy/default_policy.js
+++ b/client/src/js/pages/policy/default_policy.js
@@ -205,21 +205,21 @@ const DEFAULT_POLICY = {
 		type: "abolish"
 	},
 	CB_eldest: {
-		title: "Child Benefit",
+		title: "Child Benefit amount (eldest)",
 		description: "Child Benefit amount for the eldest or only child",
 		default: 21.15,
 		value: 21.15,
 		max: 50,
-		summary: "Child Benefit (eldest)",
+		summary: "Change the Child Benefit for the eldest or only child to £@/week",
 		type: "weekly"
 	},
 	CB_additional: {
-		title: "Child Benefit",
+		title: "Child Benefit amount (additional)",
 		description: "Child Benefit amount for additional children",
 		default: 14,
 		value: 14,
 		max: 50,
-		summary: "Child Benefit (additional)",
+		summary: "Change the Child Benefit for additional children to £@/week",
 		type: "weekly"
 	},
 	abolish_CTC: {

--- a/client/src/js/pages/policy/default_policy.js
+++ b/client/src/js/pages/policy/default_policy.js
@@ -204,6 +204,24 @@ const DEFAULT_POLICY = {
 		summary: "Abolish Child Benefit",
 		type: "abolish"
 	},
+	CB_eldest: {
+		title: "Child Benefit",
+		description: "Child Benefit amount for the eldest or only child",
+		default: 21.15,
+		value: 21.15,
+		max: 50,
+		summary: "Child Benefit (eldest)",
+		type: "weekly"
+	},
+	CB_additional: {
+		title: "Child Benefit",
+		description: "Child Benefit amount for additional children",
+		default: 14,
+		value: 14,
+		max: 50,
+		summary: "Child Benefit (additional)",
+		type: "weekly"
+	},
 	abolish_CTC: {
 		title: "Child Tax Credit",
 		description: "This switch abolishes the Child Tax Credit",

--- a/client/src/js/pages/policy/default_policy.js
+++ b/client/src/js/pages/policy/default_policy.js
@@ -272,6 +272,15 @@ const DEFAULT_POLICY = {
 		summary: "Change the standard allowance (couple, one over 25) to £@/month",
 		type: "monthly",
 	},
+	UC_reduction_rate: {
+		title: "UC reduction rate",
+		description: "Rate at which Universal Credit is reduced with earnings above the threshold",
+		default: 63,
+		value: 63,
+		max: 100,
+		summary: "Change the reduction rate to @%",
+		type: "rate",
+	},
 };
 
 export default DEFAULT_POLICY;

--- a/policy_engine_uk/populations/charts.py
+++ b/policy_engine_uk/populations/charts.py
@@ -104,7 +104,7 @@ def add_zero_line(fig):
     return fig
 
 
-def waterfall(values, labels, gain_label="Spending", loss_label="Revenue"):
+def waterfall(values, labels, gain_label="Revenue", loss_label="Spending"):
     final_color = DARK_BLUE
     if len(labels) == 0:
         df = pd.DataFrame(

--- a/policy_engine_uk/simulation/parameters.yaml
+++ b/policy_engine_uk/simulation/parameters.yaml
@@ -77,6 +77,12 @@ UC:
 CB:
   name: Child Benefit
   variable: child_benefit
+CB_eldest:
+  name: Child Benefit (eldest)
+  parameter: benefit.child_benefit.amount.eldest
+CB_additional:
+  name: Child Benefit (additional)
+  parameter: benefit.child_benefit.amount.additional
 CTC:
   name: Child Tax Credit
   variable: child_tax_credit

--- a/policy_engine_uk/simulation/parameters.yaml
+++ b/policy_engine_uk/simulation/parameters.yaml
@@ -101,6 +101,10 @@ UC_couple_young:
 UC_couple_old:
   name: UC SA (couple, over 25)
   parameter: benefit.universal_credit.standard_allowance.amount.COUPLE_OLD
+UC_reduction_rate:
+  name: UC reduction rate
+  parameter: benefit.universal_credit.means_test.reduction_rate
+  multiplier: 1.e-2
 LVT:
   name: LVT
   parameter: tax.land_value.rate


### PR DESCRIPTION
* Fixes #253 (backwards chart label)
* Fixes #247 (UC reduction rate)
* Fixes #245 (Child Benefit parameters)
* Adds my and Nikhil's bios in the FAQ question about who built it

Here are results on reducing the UC reduction rate from 63% to 55%, using synthetic data; it looks reasonable to me:
![image](https://user-images.githubusercontent.com/6076111/135028727-fd8e1ee5-c4a8-4a3e-94c2-4050e9d3df6b.png)

![image](https://user-images.githubusercontent.com/6076111/135028746-caa1d70c-735c-4114-96cb-f499aaab584b.png)

And here's a single person's MTR change:

![image](https://user-images.githubusercontent.com/6076111/135028608-c0a8e9a0-5228-45a5-8a68-425506aab9b1.png)
