### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ rdbl
 kaleido
 google-cloud-storage>=1.42.0
 gunicorn
+PolicyEngine-Core


### PR DESCRIPTION
Hopefully this should fix the issue - dependencies need to go in the requirements.txt as well as setup.py for Docker to install.