### PR TITLE
Fix bug currently causing the client to fail to load

### DIFF
--- a/policy_engine_uk/app.py
+++ b/policy_engine_uk/app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Tuple
 from openfisca_core.parameters.parameter import Parameter
 from openfisca_core.parameters.parameter_scale import ParameterScale
@@ -33,7 +34,7 @@ CURRENT_DATE = datetime.datetime.now().strftime("%Y-%m-%d")
 
 
 class PolicyEngineUK(PolicyEngine):
-    static_folder: str = "static"
+    static_folder = Path(__file__).parent / "static"
     version: str = "0.1.11"
     cache_bucket_name: str = None  # "uk-policy-engine.appspot.com"
     Microsimulation: type = Microsimulation


### PR DESCRIPTION
As of the last 20 minutes, the site returns 404 errors on the client endpoints. This fixes that bug:
## Why the bug exists
Because the flask app now crosses two packages, shared relative paths are no longer valid in both places. Pointing to `static/` wouldn't work if the loading is outsourced to policyengine-core.
## The fix
PolicyEngine-UK's server code now provides the absolute path (some reciprocal fixes in https://github.com/PolicyEngine/policyengine-core/pull/4)