### PR TITLE
Update requirements

### DIFF
--- a/policy_engine_uk/app.py
+++ b/policy_engine_uk/app.py
@@ -35,7 +35,7 @@ CURRENT_DATE = datetime.datetime.now().strftime("%Y-%m-%d")
 
 class PolicyEngineUK(PolicyEngine):
     static_folder = Path(__file__).parent / "static"
-    version: str = "0.1.12"
+    version: str = "0.1.13"
     cache_bucket_name: str = "uk-policy-engine.appspot.com"
     Microsimulation: type = Microsimulation
     IndividualSim: type = IndividualSim
@@ -105,7 +105,7 @@ class PolicyEngineUK(PolicyEngine):
         UBI_amount = max(0, revenue / self.baseline.calc("people").sum())
         return {"UBI": float(UBI_amount)}
 
-    def parameters(self, params: dict = {}) -> dict:
+    def parameters(self, params: dict = None) -> dict:
         return POLICYENGINE_PARAMETERS
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ rdbl
 kaleido
 google-cloud-storage>=1.42.0
 gunicorn
-PolicyEngine-Core
+PolicyEngine-Core>=0.1.5

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "kaleido",
         "google-cloud-storage>=1.42.0",
         "gunicorn",
-        "PolicyEngine-Core",
+        "PolicyEngine-Core>0.1.5",
     ],
     packages=find_packages(),
 )


### PR DESCRIPTION
Bumps the requirement for policyengine-core to 0.1.5 (with the fix for caching).