### PR TITLE
Fix bad dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "kaleido",
         "google-cloud-storage>=1.42.0",
         "gunicorn",
-        "PolicyEngine-Core>0.1.5",
+        "PolicyEngine-Core>=0.1.5",
     ],
     packages=find_packages(),
 )


### PR DESCRIPTION
Previously required >0.1.5, should be >= 0.1.5 for policyengine-core.