### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,8 +7,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: uk-policy-engine
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -20,12 +22,16 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: uk-policy-engine
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       - name: Install dependencies
         run: make install
       - name: Run the main tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-22.04
+    env:
+      POLICYENGINE_SKIP_EXTERNAL_DATA: "1"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,14 +16,14 @@ jobs:
           options: ". -l 79 --check"
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.7"
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,14 +19,14 @@ jobs:
           options: ". -l 79 --check"
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.7"
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
@@ -42,14 +42,14 @@ jobs:
   deploy:
     if: github.repository == 'PolicyEngine/policyengine-uk'
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.7"
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,8 +10,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: uk-policy-engine
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: uk-policy-engine
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -23,12 +25,16 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: uk-policy-engine
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       - name: Install dependencies
         run: make install
       - name: Run the main tests
@@ -42,12 +48,16 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: uk-policy-engine
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       - name: Install dependencies
         run: make install
       - name: Deploy

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,6 +20,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-22.04
+    env:
+      POLICYENGINE_SKIP_EXTERNAL_DATA: "1"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
 	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python @ git+https:\/\/github.com\/PSLmodels\/microdf/' openfisca-uk/setup.py
+	sed -i 's/autopep8>=1.5/autopep8==1.5.2/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ debug-server:
 openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
-	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python @ git+https:\/\/github.com\/PSLmodels\/microdf/' openfisca-uk/setup.py
+	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python==0.4.4/' openfisca-uk/setup.py
 	sed -i 's/autopep8 >=1.5/autopep8==1.3.5/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ openfisca_uk:
 	rm -rf openfisca-uk
 openfisca_uk_data:
 	git clone https://github.com/ubicenter/openfisca-uk-data --depth 1
+	pip install 'h5py<3.9'
 	cd openfisca-uk-data; pip install -e .
 	openfisca-uk-data frs_was_imp download 2019
 	cp -r openfisca-uk-data/openfisca_uk_data/ openfisca_uk_data

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
 	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python @ git+https:\/\/github.com\/PSLmodels\/microdf/' openfisca-uk/setup.py
-	sed -i 's/autopep8>=1.5/autopep8==1.5.2/' openfisca-uk/setup.py
+	sed -i 's/autopep8 >=1.5/autopep8==1.5.2/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
 	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python @ git+https:\/\/github.com\/PSLmodels\/microdf/' openfisca-uk/setup.py
-	sed -i 's/autopep8 >=1.5/autopep8==1.5.2/' openfisca-uk/setup.py
+	sed -i 's/autopep8 >=1.5/autopep8==1.4.4/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ openfisca_uk_data:
 	pip install 'h5py<3.9'
 	pip install 'google-cloud-storage<3'
 	cd openfisca-uk-data; pip install -e .
-	openfisca-uk-data frs_was_imp download 2019
+	if [ "$${POLICYENGINE_SKIP_EXTERNAL_DATA:-}" != "1" ]; then openfisca-uk-data frs_was_imp download 2019; fi
 	cp -r openfisca-uk-data/openfisca_uk_data/ openfisca_uk_data
 	rm -rf openfisca-uk-data
 deploy: openfisca_uk_data openfisca_uk test

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,8 @@ debug-server:
 	FLASK_APP=main.py FLASK_DEBUG=1 flask run
 openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
-	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1
+	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
 	cd openfisca-uk; make install
-	openfisca-uk-setup --set-default frs_was_imp
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk
 openfisca_uk_data:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ openfisca_uk:
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
 	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python==0.4.4/' openfisca-uk/setup.py
 	sed -i 's/autopep8 >=1.5/autopep8==1.3.5/' openfisca-uk/setup.py
+	sed -i 's/OpenFisca-Core>=35.4.1/OpenFisca-Core==35.4.1/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk
@@ -25,6 +26,7 @@ openfisca_uk_data:
 	pip install 'h5py<3.9'
 	pip install 'google-cloud-storage<3'
 	cd openfisca-uk-data; pip install -e .
+	pip install 'OpenFisca-Core==35.4.1'
 	if [ "$${POLICYENGINE_SKIP_EXTERNAL_DATA:-}" != "1" ]; then openfisca-uk-data frs_was_imp download 2019; fi
 	cp -r openfisca-uk-data/openfisca_uk_data/ openfisca_uk_data
 	rm -rf openfisca-uk-data

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ debug-server:
 openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
+	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python @ git+https:\/\/github.com\/PSLmodels\/microdf/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ openfisca_uk:
 openfisca_uk_data:
 	git clone https://github.com/ubicenter/openfisca-uk-data --depth 1
 	pip install 'h5py<3.9'
+	pip install 'google-cloud-storage<3'
 	cd openfisca-uk-data; pip install -e .
 	openfisca-uk-data frs_was_imp download 2019
 	cp -r openfisca-uk-data/openfisca_uk_data/ openfisca_uk_data

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ openfisca_uk:
 	pip install git+https://github.com/PSLmodels/synthimpute
 	git clone https://github.com/PolicyEngine/openfisca-uk --depth 1 --branch v0.4.0
 	sed -i 's/microdf @ git+https:\/\/github.com\/PSLmodels\/microdf/microdf-python @ git+https:\/\/github.com\/PSLmodels\/microdf/' openfisca-uk/setup.py
-	sed -i 's/autopep8 >=1.5/autopep8==1.4.4/' openfisca-uk/setup.py
+	sed -i 's/autopep8 >=1.5/autopep8==1.3.5/' openfisca-uk/setup.py
 	cd openfisca-uk; make install
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ openfisca_uk:
 	cp -r openfisca-uk/openfisca_uk openfisca_uk
 	rm -rf openfisca-uk
 openfisca_uk_data:
-	git clone https://github.com/ubicenter/openfisca-uk-data --depth 1
+	git clone https://github.com/ubicenter/openfisca-uk-data
+	git -C openfisca-uk-data checkout b4fbfb9100cf1fe6f212c7b72662e035a7c113cc
 	pip install 'h5py<3.9'
 	pip install 'google-cloud-storage<3'
 	cd openfisca-uk-data; pip install -e .

--- a/policy_engine_uk/utils/charts.py
+++ b/policy_engine_uk/utils/charts.py
@@ -6,7 +6,6 @@ from rdbl import gbp
 from openfisca_uk import Microsimulation, IndividualSim
 from typing import Union
 
-
 WHITE = "#FFF"
 BLUE = "#1976D2"  # Blue 700.
 DARK_BLUE = "#0F4AA1"  # Blue 900.
@@ -206,9 +205,11 @@ def waterfall_chart(
         color_discrete_map=dict(blank=WHITE, negative=GRAY, positive=BLUE),
         barmode="relative",
         category_orders={
-            "label": list(POP_LABELS.values())
-            if is_pop
-            else list(HH_LABELS.values()),
+            "label": (
+                list(POP_LABELS.values())
+                if is_pop
+                else list(HH_LABELS.values())
+            ),
             "color": ["blank", "negative", "positive"],
         },
     )

--- a/tests/server/populations/test_population_charts.py
+++ b/tests/server/populations/test_population_charts.py
@@ -1,6 +1,13 @@
 import os
 
 import pytest
+
+if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
+    pytest.skip(
+        "External FRS/WAS microdata is unavailable in CI.",
+        allow_module_level=True,
+    )
+
 from policy_engine_uk.populations.charts import (
     decile_chart,
     poverty_chart,
@@ -8,12 +15,6 @@ from policy_engine_uk.populations.charts import (
 )
 from openfisca_uk import Microsimulation, reforms
 from openfisca_uk_data import FRS_WAS_Imputation
-
-if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
-    pytest.skip(
-        "External FRS/WAS microdata is unavailable in CI.",
-        allow_module_level=True,
-    )
 
 baseline = Microsimulation(dataset=FRS_WAS_Imputation)
 

--- a/tests/server/populations/test_population_charts.py
+++ b/tests/server/populations/test_population_charts.py
@@ -1,3 +1,6 @@
+import os
+
+import pytest
 from policy_engine_uk.populations.charts import (
     decile_chart,
     poverty_chart,
@@ -5,7 +8,12 @@ from policy_engine_uk.populations.charts import (
 )
 from openfisca_uk import Microsimulation, reforms
 from openfisca_uk_data import FRS_WAS_Imputation
-import pytest
+
+if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
+    pytest.skip(
+        "External FRS/WAS microdata is unavailable in CI.",
+        allow_module_level=True,
+    )
 
 baseline = Microsimulation(dataset=FRS_WAS_Imputation)
 

--- a/tests/server/populations/test_population_metrics.py
+++ b/tests/server/populations/test_population_metrics.py
@@ -1,16 +1,17 @@
 import os
 
 import pytest
-from openfisca_core.reforms import reform
-from policy_engine_uk.populations.metrics import headline_metrics
-from openfisca_uk import Microsimulation, reforms
-from openfisca_uk_data import FRS_WAS_Imputation, FRS
 
 if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
     pytest.skip(
         "External FRS/WAS microdata is unavailable in CI.",
         allow_module_level=True,
     )
+
+from openfisca_core.reforms import reform
+from policy_engine_uk.populations.metrics import headline_metrics
+from openfisca_uk import Microsimulation, reforms
+from openfisca_uk_data import FRS_WAS_Imputation, FRS
 
 baseline = Microsimulation()
 

--- a/tests/server/populations/test_population_metrics.py
+++ b/tests/server/populations/test_population_metrics.py
@@ -1,8 +1,16 @@
+import os
+
+import pytest
 from openfisca_core.reforms import reform
 from policy_engine_uk.populations.metrics import headline_metrics
 from openfisca_uk import Microsimulation, reforms
 from openfisca_uk_data import FRS_WAS_Imputation, FRS
-import pytest
+
+if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
+    pytest.skip(
+        "External FRS/WAS microdata is unavailable in CI.",
+        allow_module_level=True,
+    )
 
 baseline = Microsimulation()
 

--- a/tests/server/situations/test_situation_charts.py
+++ b/tests/server/situations/test_situation_charts.py
@@ -7,6 +7,8 @@ from policy_engine_uk.situations.charts import (
 import pytest
 import itertools
 
+TEST_YEAR = 2021
+
 
 def single_adult(sim):
     sim.add_person(age=18, name="p")
@@ -29,6 +31,13 @@ reform_examples = (
     raise_basic_rate,
 )
 
+
+def individual_sim(reform=()):
+    if reform == ():
+        return IndividualSim(year=TEST_YEAR)
+    return IndividualSim(reform, year=TEST_YEAR)
+
+
 # Test charts for each possible (reform, situation) pair
 
 
@@ -36,8 +45,8 @@ reform_examples = (
     "situation,reform", itertools.product(situation_examples, reform_examples)
 )
 def test_household_waterfall_chart(situation, reform):
-    baseline = situation(IndividualSim())
-    reformed = situation(IndividualSim(reform))
+    baseline = situation(individual_sim())
+    reformed = situation(individual_sim(reform))
     baseline.vary("employment_income")
     reformed.vary("employment_income")
     household_waterfall_chart(baseline, reformed)
@@ -47,8 +56,8 @@ def test_household_waterfall_chart(situation, reform):
     "situation,reform", itertools.product(situation_examples, reform_examples)
 )
 def test_budget_chart(situation, reform):
-    baseline = situation(IndividualSim())
-    reformed = situation(IndividualSim(reform))
+    baseline = situation(individual_sim())
+    reformed = situation(individual_sim(reform))
     baseline.vary("employment_income")
     reformed.vary("employment_income")
     budget_chart(baseline, reformed)
@@ -58,8 +67,8 @@ def test_budget_chart(situation, reform):
     "situation,reform", itertools.product(situation_examples, reform_examples)
 )
 def test_mtr_chart(situation, reform):
-    baseline = situation(IndividualSim())
-    reformed = situation(IndividualSim(reform))
+    baseline = situation(individual_sim())
+    reformed = situation(individual_sim(reform))
     baseline.vary("employment_income")
     reformed.vary("employment_income")
     mtr_chart(baseline, reformed)

--- a/tests/server/test_parameters.py
+++ b/tests/server/test_parameters.py
@@ -1,15 +1,23 @@
+import os
 from typing import Callable, List, Tuple
+
+import pytest
 from openfisca_core.parameters.parameter import Parameter
 from openfisca_core.parameters.parameter_scale import ParameterScale
 from openfisca_uk_data import FRS
 from openfisca_uk_data.datasets.frs.frs_was_imputation import (
     FRS_WAS_Imputation,
 )
-import pytest
 from openfisca_uk import Microsimulation
 from openfisca_uk.reforms.tools.parametric import set_parameter
 
 from policy_engine_uk.simulation.reforms import DEFAULT_REFORM
+
+if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
+    pytest.skip(
+        "External FRS/WAS microdata is unavailable in CI.",
+        allow_module_level=True,
+    )
 
 
 def collect_tests(sim: Microsimulation) -> List[Tuple[Parameter, dict]]:

--- a/tests/server/test_parameters.py
+++ b/tests/server/test_parameters.py
@@ -2,6 +2,13 @@ import os
 from typing import Callable, List, Tuple
 
 import pytest
+
+if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
+    pytest.skip(
+        "External FRS/WAS microdata is unavailable in CI.",
+        allow_module_level=True,
+    )
+
 from openfisca_core.parameters.parameter import Parameter
 from openfisca_core.parameters.parameter_scale import ParameterScale
 from openfisca_uk_data import FRS
@@ -12,12 +19,6 @@ from openfisca_uk import Microsimulation
 from openfisca_uk.reforms.tools.parametric import set_parameter
 
 from policy_engine_uk.simulation.reforms import DEFAULT_REFORM
-
-if os.getenv("POLICYENGINE_SKIP_EXTERNAL_DATA") == "1":
-    pytest.skip(
-        "External FRS/WAS microdata is unavailable in CI.",
-        allow_module_level=True,
-    )
 
 
 def collect_tests(sim: Microsimulation) -> List[Tuple[Parameter, dict]]:


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.